### PR TITLE
feat: add BH plot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ mcc --help
 # תיקון BH/By/Holm לערכי p מתוך CSV (עמודה pval)
 mcc correct --csv examples/demo_pvalues.csv --col pval --alpha 0.05 --method fdr_bh --out results_bh.csv
 
+# עם גרף BH המציג את סף הדחייה
+mcc correct --csv examples/demo_pvalues.csv --col pval --alpha 0.05 --method fdr_bh --out results_bh.csv --plot
+
 # Tukey HSD לאחר ANOVA
 mcc tukey --csv examples/demo_anova.csv --group group --value value --alpha 0.05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "numpy>=1.23",
   "pandas>=2.0",
   "statsmodels>=0.14",
-  "matplotlib>=3.7",
+  "matplotlib>=3.7", # required for --plot flag
 ]
 
 [project.scripts]

--- a/src/mc_cc0/cli.py
+++ b/src/mc_cc0/cli.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import argparse, sys, json
+import numpy as np
 import pandas as pd
-from mc_cc0.corrections import apply_correction
+from mc_cc0.corrections import apply_correction, bh_threshold
 from mc_cc0.anova_posthoc import tukey_hsd
 from mc_cc0.decision_flow import Context, recommend
 from mc_cc0.ssm_guardrail import check_guardrail
@@ -19,6 +20,7 @@ def main():
     c.add_argument("--method", choices=METHODS, default="holm")
     c.add_argument("--out", default="results_corrected.csv")
     c.add_argument("--n", type=int, default=1000, help="Sample size for guardrail check")
+    c.add_argument("--plot", action="store_true", help="Generate BH diagnostic plot")
     
     t = sub.add_parser("tukey", help="Tukey HSD post-hoc after ANOVA")
     t.add_argument("--csv", required=True)
@@ -40,12 +42,39 @@ def main():
     if args.cmd == "correct":
         guard = check_guardrail(args.n)
         df = pd.read_csv(args.csv)
-        reject, p_corr = apply_correction(df[args.col], args.alpha, method=args.method)
+        pvals = df[args.col]
+        reject, p_corr = apply_correction(pvals, args.alpha, method=args.method)
         out = df.copy()
         out["reject"] = reject
         out["p_adj"] = p_corr
         out.to_csv(args.out, index=False)
-        print(json.dumps({"guardrail": guard, "out": args.out, "method": args.method, "alpha": args.alpha}, ensure_ascii=False))
+        result = {"guardrail": guard, "out": args.out, "method": args.method, "alpha": args.alpha}
+        plot_path = None
+        if args.plot:
+            import matplotlib.pyplot as plt
+            bh = bh_threshold(pvals.to_numpy(), args.alpha)
+            p_sorted = np.sort(pvals.to_numpy())
+            m = p_sorted.size
+            k = np.arange(1, m + 1)
+            crit = (k / m) * args.alpha
+            fig, ax = plt.subplots()
+            ax.scatter(k, p_sorted, label="p-values")
+            ax.plot(k, crit, label="k/m·q")
+            mask = p_sorted <= crit
+            if mask.any():
+                k_cut = np.max(np.where(mask)[0]) + 1
+                ax.scatter(k_cut, p_sorted[k_cut-1], color="red", zorder=5, label="cutoff")
+                ax.axvline(k_cut, color="red", linestyle="--")
+                ax.axhline(bh, color="red", linestyle="--")
+            ax.set_xlabel("k")
+            ax.set_ylabel("p-value")
+            ax.legend()
+            plot_path = args.out.rsplit('.', 1)[0] + '.png'
+            fig.savefig(plot_path, dpi=150, bbox_inches="tight")
+            result["plot"] = plot_path
+        print(json.dumps(result, ensure_ascii=False))
+        if plot_path:
+            print(f"![BH plot]({plot_path})")
         return
 
     if args.cmd == "tukey":


### PR DESCRIPTION
## Summary
- add `--plot` flag to `mcc correct` for BH diagnostic plot and markdown snippet
- document `--plot` usage in README
- note `matplotlib` dependency in pyproject

## Testing
- `python -m pytest`
- `PYTHONPATH=src python src/mc_cc0/cli.py correct --csv examples/demo_pvalues.csv --col pval --alpha 0.05 --method fdr_bh --out tmp_results.csv --plot`

------
https://chatgpt.com/codex/tasks/task_e_689cd99fc9788326b9da40365115de11