### PR TITLE
ci: expand workflow and deploy pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,31 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Install
         run: |
           python -m pip install --upgrade pip
           pip install -e .
           pip install pytest
       - name: Run tests
+        env:
+          MPLBACKEND: Agg
         run: pytest -q
+      - name: Upload artifacts (optional)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ matrix.python-version }}
+          path: |
+            **/*bh_plot*.png
+            **/results_*.csv
+          if-no-files-found: ignore

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare site
+        run: |
+          mkdir -p dist
+          cp -r web/* dist/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Multiple-Comparisons CC0 Toolkit (FWER/FDR) — עם שמירת SSM-Guardrail
 
+[![CI](https://github.com/<user>/psychic-octo-guacamole/actions/workflows/ci.yml/badge.svg)](https://github.com/<user>/psychic-octo-guacamole/actions/workflows/ci.yml)
+[![Pages](https://img.shields.io/badge/Pages-live-blue?logo=github)](https://<user>.github.io/psychic-octo-guacamole/)
+
 **מטרת הפרויקט:** חבילת CC0 קלה לשימוש לבקרת השוואות מרובות (FWER/FDR), עם קוד Python, אפליקציית ווב סטטית (HTML+JS), 
 וקטעי קוד לדוחות. בנוי לפי עקרונות OpenDecision‑SSM: קבלת החלטות שקופה, שמרנות מבוקרת, והפרדה בין אישוש לאמידה.
 


### PR DESCRIPTION
## Summary
- extend CI to test against Python 3.10–3.12 with pip caching and BH/IHW artifact upload
- add GitHub Pages deployment workflow for static web app
- document build and Pages status badges in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce3ebd9588326a870746668a84332